### PR TITLE
Collect screen blank state without using statefs

### DIFF
--- a/measure/endurance-snapshot
+++ b/measure/endurance-snapshot
@@ -84,14 +84,6 @@ parse_from_release_file() {
 	sed -n "s/^${value}=\"\?\([^\"]*\)\"\?$/\1/p" "$file"
 }
 
-dump_statefs_value() {
-	STATEFS_DIR=/run/state
-	file=$STATEFS_DIR/$1
-	if [ -f "$file" ]; then
-		echo "$1="$(cat "$file") >> $path/statefs
-	fi
-}
-
 # do some basic sanity checks
 if type proc2csv >/dev/null 2>/dev/null ; then
 	PROC2CSV="proc2csv"
@@ -475,8 +467,12 @@ fi
 echo "- Disk usage"
 LC_ALL=C df -k -P > $path/df
 
-echo "- statefs"
-dump_statefs_value namespaces/Screen/Blanked
+# Collect screen blanking info from mce if it's available
+if type mcetool >/dev/null 2>/dev/null ; then
+	echo "- mce display stats"
+	# Stores the output from mcetool display stats
+	mcetool --get-display-stats=machine 2>/dev/null > $path/mce_display_stats
+fi
 
 # and syslog...
 logs=""

--- a/postproc-lib/lib/SP/Endurance/Parser.pm
+++ b/postproc-lib/lib/SP/Endurance/Parser.pm
@@ -1391,14 +1391,15 @@ sub parse_os_release {
     return \%result;
 }
 
-sub parse_statefs {
+sub parse_mce_display_stats {
     my $fh = shift;
 
     my %result;
 
     while (<$fh>) {
-        if (/^(?<path>[^=]+)=(?<value>.+)$/) {
-            $result{$+{path}} = $+{value};
+        if (/^(?<path>[^ ]+) *(?<value>[^ ]+) *(?<numtimes>.+)$/) {
+            $result{"$+{path}/duration"} = $+{value};
+            $result{"$+{path}/times"} = $+{numtimes};
         }
     }
 
@@ -1473,7 +1474,7 @@ sub parse_dir {
         '/usr/bin/bmestat'         => parse_bmestat(copen $name . '/bmestat'),
         '/usr/bin/xmeminfo'        => parse_xmeminfo(copen $name . '/xmeminfo'),
         display_state              => parse_display_state(copen $name . '/journal'),
-        statefs                    => parse_statefs(copen $name . '/statefs'),
+        mce_display_stats          => parse_mce_display_stats(copen $name . '/mce_display_stats'),
         '/sys/devices/virtual/kgsl/kgsl/proc'	=> parse_sysfs_kgsl(copen $name . '/sysfs_kgsl')
     };
 


### PR DESCRIPTION
This is the last case where statefs is used, so removes the use of statefs entirely.

measure/endurance-snapshot: remove use of statefs
postproc-lib: use blanking data instead of statefs

This is still WIP.